### PR TITLE
[DEBUG] Disable verification of certificates @ Rally 2.3.1

### DIFF
--- a/esrally/utils/net.py
+++ b/esrally/utils/net.py
@@ -46,7 +46,7 @@ def init():
         )
     else:
         logger.info("Connecting directly to the Internet (no proxy support).")
-        __HTTP = urllib3.PoolManager(cert_reqs="CERT_REQUIRED", ca_certs=certifi.where())
+        __HTTP = urllib3.PoolManager(cert_reqs='CERT_NONE'))
 
 
 class Progress:

--- a/esrally/utils/net.py
+++ b/esrally/utils/net.py
@@ -46,7 +46,7 @@ def init():
         )
     else:
         logger.info("Connecting directly to the Internet (no proxy support).")
-        __HTTP = urllib3.PoolManager(cert_reqs='CERT_NONE'))
+        __HTTP = urllib3.PoolManager(cert_reqs='CERT_NONE')
 
 
 class Progress:


### PR DESCRIPTION
While using Minikube deployment, it's possible that Rally wouldn't be able to download default tracks due to certificate verification failure. 
Within the PR, it had been disabled in debug purposes.